### PR TITLE
[#8][#17] Downgrade the version of conda

### DIFF
--- a/helms/odahu-flow-packagers/templates/packers/docker.yaml
+++ b/helms/odahu-flow-packagers/templates/packers/docker.yaml
@@ -21,9 +21,6 @@ data:
           - name: docker-pull
             connectionTypes: ["docker", "ecr"]
             required: false
-          - name: archive-storage
-            connectionTypes: ["s3", "gcs", "azureblob"]
-            required: false
         arguments:
           properties:
             - name: dockerfileAddCondaInstallation
@@ -82,9 +79,6 @@ data:
             required: true
           - name: docker-pull
             connectionTypes: ["docker", "ecr"]
-            required: false
-          - name: archive-storage
-            connectionTypes: ["s3", "gcs", "azureblob"]
             required: false
         arguments:
           properties:

--- a/packagers/docker/odahuflow/packager/cli/resources/conda.Dockerfile
+++ b/packagers/docker/odahuflow/packager/cli/resources/conda.Dockerfile
@@ -1,6 +1,6 @@
 # Installing conda
 
-ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh
+ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     PATH="/opt/conda/bin:${PATH}"

--- a/packagers/docker/odahuflow/packager/helpers/constants.py
+++ b/packagers/docker/odahuflow/packager/helpers/constants.py
@@ -35,7 +35,6 @@ HANDLER_APP = 'app'
 
 TARGET_DOCKER_REGISTRY = 'docker-push'
 PULL_DOCKER_REGISTRY = 'docker-pull'
-TARGET_ARCHIVE_STORAGE = 'archive-storage'
 
 DOCKER_IMAGE_RESULT = 'image'
 RESULT_FILE_NAME = 'result.json'

--- a/packagers/docker/odahuflow/packager/helpers/io_proc_utils.py
+++ b/packagers/docker/odahuflow/packager/helpers/io_proc_utils.py
@@ -17,7 +17,6 @@ import logging
 import os.path
 import stat
 import subprocess
-import zipfile
 
 LOGGER = logging.getLogger(__name__)
 
@@ -107,30 +106,3 @@ def remove_directory(path):
             raise Exception('Not a directory or file: %s' % path)
     finally:
         pass
-
-
-def create_zip_archive(source_folder: str, archive_name: str, target_folder: str):
-    """
-    Create ZIP archive named <archive_name> in <target_folder> from folder <source_folder>
-
-    :param source_folder: source folder
-    :type source_folder: str
-    :param archive_name: name of result archive (only file name, without folder)
-    :type archive_name: str
-    :param target_folder: target folder name (where archive will be placed)
-    :type target_folder: str
-    :return: str -- path to final archive
-    """
-    target_path = os.path.join(target_folder, archive_name)
-    source_folder = os.path.abspath(source_folder)
-
-    # Create archive
-    zip_file = zipfile.ZipFile(target_path, 'w', zipfile.ZIP_DEFLATED)
-    for root, _, files in os.walk(source_folder):
-        for file in files:
-            local_path = os.path.join(root, file)
-            arcname = local_path.replace(source_folder, '').lstrip(os.path.sep)
-            zip_file.write(local_path, arcname=arcname)
-    zip_file.close()
-
-    return target_path

--- a/packagers/docker/odahuflow/packager/helpers/utils.py
+++ b/packagers/docker/odahuflow/packager/helpers/utils.py
@@ -43,8 +43,4 @@ def build_image_name(name_template: str, values: TemplateNameValues) -> str:
     if not values.RandomUUID:
         values.RandomUUID = str(uuid.uuid4())
 
-    return Template(name_template).render(values.dict())
-
-
-def build_archive_name(model_name: str, model_version: str) -> str:
-    return f'{model_name}-{model_version}.zip'
+    return Template(name_template).render(values.dict()).lower()

--- a/packagers/docker/odahuflow/packager/rest/resources/conda.Dockerfile
+++ b/packagers/docker/odahuflow/packager/rest/resources/conda.Dockerfile
@@ -1,6 +1,6 @@
 # Installing conda
 
-ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh
+ARG MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     PATH="/opt/conda/bin:${PATH}"

--- a/packagers/docker/tests/test_name.py
+++ b/packagers/docker/tests/test_name.py
@@ -17,7 +17,8 @@
 import re
 
 from odahuflow.packager.helpers.constants import DEFAULT_IMAGE_NAME_TEMPLATE
-from odahuflow.packager.helpers.utils import build_image_name, TemplateNameValues
+from odahuflow.packager.helpers.utils import build_image_name, \
+    TemplateNameValues
 
 
 def test_without_template() -> None:
@@ -26,19 +27,36 @@ def test_without_template() -> None:
     """
     docker_image_name = "test:1234"
 
-    result = build_image_name(docker_image_name, TemplateNameValues(Name='name', Version='version'))
+    result = build_image_name(docker_image_name, TemplateNameValues(
+        Name='name', Version='version'
+    ))
     assert docker_image_name == result
 
 
 def test_basic_template_name() -> None:
     result = build_image_name('{{ Name }}/{{ RandomUUID }}:{{ Version }}',
-                              TemplateNameValues(Name='name', Version='version', RandomUUID="1234"))
+                              TemplateNameValues(
+                                  Name='name',
+                                  Version='version',
+                                  RandomUUID="1234"
+                              ))
+    assert result == 'name/1234:version'
+
+
+def test_lower_case_name() -> None:
+    result = build_image_name('{{ Name }}/{{ RandomUUID }}:{{ Version }}',
+                              TemplateNameValues(
+                                  Name='NAME',
+                                  Version='VERSION',
+                                  RandomUUID="1234"
+                              ))
     assert result == 'name/1234:version'
 
 
 def test_empty_random_uuid() -> None:
     result = build_image_name('{{ Name }}/{{ RandomUUID }}:{{ Version }}',
-                              TemplateNameValues(Name='name', Version='version'))
+                              TemplateNameValues(Name='name',
+                                                 Version='version'))
 
     assert re.match(r'name/([\d\w\-]+):version', result)
 
@@ -48,6 +66,7 @@ def test_default_image_template_name() -> None:
     Check that the default image template works as expected
     """
     result = build_image_name(DEFAULT_IMAGE_NAME_TEMPLATE,
-                              TemplateNameValues(Name='name', Version='version'))
+                              TemplateNameValues(Name='name',
+                                                 Version='version'))
 
     assert re.match(r'name-version:([\d\w\-]+)', result)


### PR DESCRIPTION
The new version of conda get stuck during its installation
randomly. So we decided to downgrade it.

Removed the obsolete `archive-storage` target.

Forced lower case for docker image names because
some docker registries does not support the upper case.

This closes #8 
This closes #17 