### PR TITLE
[feat] Improved performance of packagers

### DIFF
--- a/containers/docker-packager/Dockerfile
+++ b/containers/docker-packager/Dockerfile
@@ -21,7 +21,7 @@ ENV WORK_DIR="/opt/odahu-flow"
 WORKDIR "${WORK_DIR}/"
 
 RUN dnf -y update && dnf -y reinstall shadow-utils && \
-    dnf -y install buildah runc fuse-overlayfs python3-pip --exclude container-selinux && \
+    dnf -y install buildah runc python3-pip --exclude container-selinux && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 COPY containers/docker-packager/registries.conf \

--- a/containers/docker-packager/storage.conf
+++ b/containers/docker-packager/storage.conf
@@ -1,14 +1,13 @@
 [storage]
 driver = "overlay"
-runroot = "/var/run/containers/storage"
-graphroot = "/var/lib/containers/storage"
+runroot = "/workspace/var/run/containers/storage"
+graphroot = "/workspace/var/lib/containers/storage"
 
 [storage.options]
 additionalimagestores = []
 size = ""
-mount_program = "/usr/bin/fuse-overlayfs"
 override_kernel_check = "true"
-mountopt = "nodev,metacopy=on"
+mountopt = "nodev"
 
 [storage.options.thinpool]
 ostree_repo = ""


### PR DESCRIPTION
* Buildah images and contain are located in the /workspace volume dir.
* Removed metacopy, because it's supported only on new 4.19+ kernels.

This closes #26 #19 