### PR TITLE
fix: we should authorize while docker built image push. 

### DIFF
--- a/packagers/odahuflow/packager/helpers/docker_builder.py
+++ b/packagers/odahuflow/packager/helpers/docker_builder.py
@@ -157,7 +157,7 @@ def _authorize_docker(client: docker.DockerClient, connection: Connection,
 
     logging.info('Trying to authorize %r on %r using password %r',
                  login, registry,
-                 '*' * len(connection.spec.password))
+                 '*' * 5)
     client.login(username=login,
                  password=password,
                  registry=registry,
@@ -231,11 +231,7 @@ def push_docker_image_docker(external_docker_name, push_connection: typing.Optio
 
     log_generator = client.images.push(
         repository=remote_tag,
-        stream=True,
-        auth_config={
-            'username': push_connection.spec.username,
-            'password': push_connection.spec.password
-        }
+        stream=True
     )
 
     for line in log_generator:

--- a/tests/cli/test_cli_packager.py
+++ b/tests/cli/test_cli_packager.py
@@ -100,7 +100,8 @@ def mock_push(*args, **kwargs):
     yield 'Image is not pushed because of mocking'
 
 
-def test_cli(tmp_path, packager_manifest_file: str):
+@mock.patch('odahuflow.packager.helpers.docker_builder._authorize_docker')
+def test_cli(_, tmp_path, packager_manifest_file: str):
     logging.basicConfig(level=logging.DEBUG)
 
     model_path = os.path.join(RESOURCES_DIR, 'simple-model')


### PR DESCRIPTION
Create registry if ecr.

close [[466] cannot push a docker image to ECR registry when running local packaging with spec on host or cluster](https://github.com/odahu/odahu-flow/issues/466)