### PR TITLE
updated docker-triton targets 

### DIFF
--- a/helms/odahu-flow-packagers/templates/packers/docker.yaml
+++ b/helms/odahu-flow-packagers/templates/packers/docker.yaml
@@ -149,6 +149,10 @@ data:
             connectionTypes: ["docker", "ecr"]
             default: "{{ .Values.packagers.triton.targets.docker_push.default }}"
             required: true
+          - name: docker-pull
+            connectionTypes: ["docker", "ecr"]
+            default: "{{ .Values.packagers.triton.targets.docker_pull.default }}"
+            required: false
         arguments:
           properties:
             - name: triton_base_image_tag

--- a/helms/odahu-flow-packagers/values.yaml
+++ b/helms/odahu-flow-packagers/values.yaml
@@ -39,7 +39,7 @@ packagers:
         # Default connection ID
         # Type: str
         default: ""
-      # Configuration of docker-push target
+      # Configuration of docker-pull target
       # Type: dict
       docker_pull:
         # Default connection ID
@@ -64,7 +64,7 @@ packagers:
         # Default connection ID
         # Type: str
         default: ""
-      # Configuration of docker-push target
+      # Configuration of docker-pull target
       # Type: dict
       docker_pull:
         # Default connection ID
@@ -86,6 +86,12 @@ packagers:
       # Configuration of docker-push target
       # Type: dict
       docker_push:
+        # Default connection ID
+        # Type: str
+        default: ""
+      # Configuration of docker-pull target
+      # Type: dict
+      docker_pull:
         # Default connection ID
         # Type: str
         default: ""


### PR DESCRIPTION
added target docker-pull for docker-triton packager
this PR & https://github.com/odahu/odahu-automation/pull/71 closes https://github.com/odahu/odahu-packager/issues/40